### PR TITLE
Core/Content.js options

### DIFF
--- a/Demo/demo-dock-only.html
+++ b/Demo/demo-dock-only.html
@@ -88,19 +88,21 @@
 			new MUI.Modal({
 				id: 'about',
 				title: 'MochaUI',
-				loadMethod: 'xhr',
-				contentURL: 'pages/about.html',
 				type: 'modal2',
 				width: 350,
 				height: 195,
-				contentBgColor: '#e5e5e5 url(images/logo2.gif) left 3px no-repeat',
+				// contentBgColor: '#e5e5e5 url(images/logo2.gif) left 3px no-repeat',
 				padding: { top: 43, right: 12, bottom: 10, left: 12 },
-				scrollbars: false
+				scrollbars: false,
+				content: {
+					loadMethod: 'xhr',
+					url: 'pages/about.html'
+				}
 			});
 		};
 		
 		window.addEvent('load', function(){
-			MUI.Windows.windowOptions.container = 'pageWrapper';
+			MUI.Windows.options.container = 'pageWrapper';
 			MUI.Desktop.initialize();
 			MUI.Windows.newFromHTML();
 			

--- a/Demo/demo-fixed-width.html
+++ b/Demo/demo-fixed-width.html
@@ -112,19 +112,21 @@
 			new MUI.Modal({
 				id: 'about',
 				title: 'MochaUI',
-				loadMethod: 'xhr',
-				contentURL: 'pages/about.html',
 				type: 'modal2',
 				width: 350,
 				height: 195,
 				contentBgColor: '#e5e5e5 url(images/logo2.gif) left 3px no-repeat',
 				padding: { top: 43, right: 12, bottom: 10, left: 12 },
-				scrollbars:  false
+				scrollbars:  false,
+				content: {
+					loadMethod: 'xhr',
+					url: 'pages/about.html'
+				}
 			});
 		};
 
 		window.addEvent('load', function() {
-			MUI.Windows.windowOptions.container = 'pageWrapper';
+			MUI.Windows.options.container = 'pageWrapper';
 			MUI.Desktop.initialize();
 			MUI.Windows.newFromHTML();
 

--- a/Demo/demo-no-desktop.html
+++ b/Demo/demo-no-desktop.html
@@ -34,8 +34,10 @@
 			new MUI.Window({
 				id: 'test',
 				title: 'Test',
-				loadMethod: 'xhr',
-				contentURL: 'pages/lipsum.html'
+				content: {
+					loadMethod: 'xhr',
+					url: 'pages/lipsum.html'
+				}
 			});
 		};
 

--- a/Demo/demo-no-toolbars.html
+++ b/Demo/demo-no-toolbars.html
@@ -31,26 +31,30 @@
 
 	<script type="text/javascript">
 
-		// Initialize MochaUI options
-		MUI.initialize();
-
 		MUI.aboutWindow = function() {
 			new MUI.Modal({
 				id: 'about',
 				title: 'MochaUI',
-				loadMethod: 'xhr',
-				contentURL: 'pages/about.html',
 				type: 'modal2',
 				width: 350,
 				height: 195,
-				contentBgColor: '#e5e5e5 url(images/logo2.gif) left 3px no-repeat',
+				//contentBgColor: '#e5e5e5 url(images/logo2.gif) left 3px no-repeat',
 				padding: { top: 43, right: 12, bottom: 10, left: 12 },
-				scrollbars:  false
+				scrollbars:  false,
+				content: {
+					loadMethod: 'xhr',
+					url: 'pages/about.html'
+				}
 			});
 		};
 
 		window.addEvent('load', function() {
-			MUI.Desktop.initialize();
+
+			// Initialize MochaUI options
+			MUI.initialize();
+		
+			//MUI.Desktop.initialize();
+			
 			MUI.Windows.newFromHTML();
 
 			$('aboutLink').addEvent('click', function(e) {

--- a/Demo/scripts/demo-virtual-desktop-init.js
+++ b/Demo/scripts/demo-virtual-desktop-init.js
@@ -31,7 +31,7 @@
  3. Add link events to build future windows
 
  if ($('myWindowLink')){
- $('myWindowLink').addEvent('click', function(e) {
+ $('myWindowLink').addEvent('click', function(e){
  new Event(e).stop();
  jsonWindows();
  });
@@ -55,40 +55,42 @@
 
  -------------------------------------------------------------------- */
 
-initializeWindows = function() {
+initializeWindows = function(){
 
 	// change default setting - keep window within inside the main area.
 	MUI.Windows.options.container = 'pageWrapper';
 
 	// Examples
-	MUI.ajaxpageWindow = function() {
+	MUI.ajaxpageWindow = function(){
 		new MUI.Window({
 			id: 'ajaxpage',
-			loadMethod: 'xhr',
-			content: { url:'pages/lipsum.html' },
+			content: {
+				url:'pages/lipsum.html',
+				loadMethod: 'xhr'
+			},
 			width: 340,
 			height: 150
 		});
 	};
-	if ($('ajaxpageLinkCheck')) {
-		$('ajaxpageLinkCheck').addEvent('click', function(e) {
+	if ($('ajaxpageLinkCheck')){
+		$('ajaxpageLinkCheck').addEvent('click', function(e){
 			e.stop();
 			MUI.ajaxpageWindow();
 		});
 	}
 
-	MUI.jsonWindows = function() {
+	MUI.jsonWindows = function(){
 		var url = 'data/json-windows-data.js';
 		var request = new Request.JSON({
 			url: url,
 			method: 'get',
-			onComplete: function(properties) {
+			onComplete: function(properties){
 				MUI.Windows.newFromJSON(properties.windows);
 			}
 		}).send();
 	};
-	if ($('jsonLink')) {
-		$('jsonLink').addEvent('click', function(e) {
+	if ($('jsonLink')){
+		$('jsonLink').addEvent('click', function(e){
 			e.stop();
 			MUI.jsonWindows();
 		});
@@ -98,76 +100,93 @@ initializeWindows = function() {
 		new MUI.Window({
 			id: 'youtube',
 			title: 'YouTube in Iframe',
-			loadMethod: 'iframe',
 			width: 340,
 			height: 280,
 			resizeLimit: {'x': [330, 2500], 'y': [250, 2000]},
 			content: [
-				{ url: 'pages/youtube.html' },
 				{
-				'position': 'top',
-				section: 'toolbar',
-				loadMethod:'json',
-				content: [
-					{'text':'Zero 7','url':'pages/youtube.html','title':'Zero 7'},
-					{'text':'Fleet Foxes','url':'pages/youtube2.html','title':'Fleet Foxes'},
-					{'text':'Boards of Canada','url':'pages/youtube3.html','title':'Boards of Canada'}
-				],
-				onLoaded: function(element,uOptions,json) {
-					MUI.create('MUI.Tabs',{
-						'id':'youtube_toolbar',
-						'container':'youtube',
-						'position': 'top',
-						'tabs':json,
-						'partner':'youtube',
-						'section':'toolbar'
-					})
+					url: 'pages/youtube.html',
+					loadMethod: 'iframe'
+				},
+				{
+					'position': 'top',
+					section: 'toolbar',
+					loadMethod:'json',
+					content: [
+						{'text': 'Zero 7','url':'pages/youtube.html','title':'Zero 7'},
+						{'text': 'Fleet Foxes','url':'pages/youtube2.html','title':'Fleet Foxes'},
+						{'text': 'Boards of Canada','url':'pages/youtube3.html','title':'Boards of Canada'}
+					],
+					onLoaded: function(element,uOptions,json){
+						MUI.create('MUI.Tabs',{
+							'id': 'youtube_toolbar',
+							'container': 'youtube',
+							'position': 'top',
+							'tabs': json,
+							'partner': 'youtube',
+							'section': 'toolbar'
+						});
+					}
 				}
-			}]
+			]
 		});
 	};
-	if ($('youtubeLinkCheck')) {
-		$('youtubeLinkCheck').addEvent('click', function(e) {
+	if ($('youtubeLinkCheck')){
+		$('youtubeLinkCheck').addEvent('click', function(e){
 			e.stop();
 			MUI.youtubeWindow();
 		});
 	}
 
-	MUI.clockWindow = function() {
+	MUI.clockWindow = function(){
 		new MUI.Window({
 			id: 'clock',
 			title: 'Canvas Clock',
 			addClass: 'transparent',
-			loadMethod: 'xhr',
-			content: { url:'{plugins}coolclock/index.html' },
+			content: {
+				url:'{plugins}coolclock/index.html',
+				loadMethod: 'xhr',
+				require: {
+					js: ['{plugins}coolclock/scripts/coolclock.js'],
+					onload: function(){
+						if (CoolClock) new CoolClock();
+					}
+				}
+			},
 			shape: 'gauge',
 			headerHeight: 30,
 			width: 160,
 			height: 160,
 			x: 570,
 			y: 152,
-			padding: { top: 0, right: 0, bottom: 0, left: 0 },
-			require: {
-				js: ['{plugins}coolclock/scripts/coolclock.js'],
-				onload: function() {
-					if (CoolClock) new CoolClock();
-				}
-			}
+			padding: {top: 0, right: 0, bottom: 0, left: 0}
 		});
 	};
-	if ($('clockLinkCheck')) {
-		$('clockLinkCheck').addEvent('click', function(e) {
+	if ($('clockLinkCheck')){
+		$('clockLinkCheck').addEvent('click', function(e){
 			e.stop();
 			MUI.clockWindow();
 		});
 	}
 
-	MUI.parametricsWindow = function() {
+	MUI.parametricsWindow = function(){
 		new MUI.Window({
 			id: 'parametrics',
 			title: 'Window Parametrics',
-			loadMethod: 'xhr',
-			content: { url: '{plugins}parametrics/index.html' },
+			content: {
+				url: '{plugins}parametrics/index.html',
+				loadMethod: 'xhr',
+				require: {
+					css: ['{plugins}parametrics/css/style.css'],
+					js: ['{plugins}parametrics/scripts/parametrics.js'],
+					onload: function(){
+						if (MUI.addRadiusSlider) MUI.addRadiusSlider();
+						if (MUI.addShadowSlider) MUI.addShadowSlider();
+						if (MUI.addOffsetXSlider) MUI.addOffsetXSlider();
+						if (MUI.addOffsetYSlider) MUI.addOffsetYSlider();
+					}
+				}
+			},
 			width: 305,
 			height: 210,
 			x: 230,
@@ -175,27 +194,24 @@ initializeWindows = function() {
 			padding: { top: 12, right: 12, bottom: 10, left: 12 },
 			resizable: false,
 			maximizable: false,
-			require: {
-				css: ['{plugins}parametrics/css/style.css'],
-				js: ['{plugins}parametrics/scripts/parametrics.js'],
-				onload: function() {
-					if (MUI.addRadiusSlider) MUI.addRadiusSlider();
-					if (MUI.addShadowSlider) MUI.addShadowSlider();
-					if (MUI.addOffsetXSlider) MUI.addOffsetXSlider();
-					if (MUI.addOffsetYSlider) MUI.addOffsetYSlider();
-				}
+			onDragStart: function(instance){
+				if (!Browser.Engine.trident) instance.el.windowEl.setStyle('opacity', 0.5);
+				// VML doesn't render opacity nicely on the shadow
+			},
+			onDragComplete: function(instance){
+				if (!Browser.Engine.trident) instance.el.windowEl.setStyle('opacity', 1);
 			}
 		});
 	};
-	if ($('parametricsLinkCheck')) {
-		$('parametricsLinkCheck').addEvent('click', function(e) {
+	if ($('parametricsLinkCheck')){
+		$('parametricsLinkCheck').addEvent('click', function(e){
 			e.stop();
 			MUI.parametricsWindow();
 		});
 	}
 
 	// Examples > Tests
-	MUI.eventsWindow = function() {
+	MUI.eventsWindow = function(){
 		new MUI.Window({
 			id: 'windowevents',
 			title: 'Window Events',
@@ -203,40 +219,40 @@ initializeWindows = function() {
 			content: { url: 'pages/events.html' },
 			width: 340,
 			height: 250,
-			onLoaded: function() {
+			onLoaded: function(){
 				MUI.notification('Window content was loaded.');
 			},
-			onCloseComplete: function() {
+			onCloseComplete: function(){
 				MUI.notification('The window is closed.');
 			},
-			onMinimize: function() {
+			onMinimize: function(){
 				MUI.notification('Window was minimized.');
 			},
-			onMaximize: function() {
+			onMaximize: function(){
 				MUI.notification('Window was maximized.');
 			},
-			onRestore: function() {
+			onRestore: function(){
 				MUI.notification('Window was restored.');
 			},
-			onResize: function() {
+			onResize: function(){
 				MUI.notification('Window was resized.');
 			},
-			onFocus: function() {
+			onFocus: function(){
 				MUI.notification('Window was focused.');
 			},
-			onBlur: function() {
+			onBlur: function(){
 				MUI.notification('Window lost focus.');
 			}
 		});
 	};
-	if ($('windoweventsLinkCheck')) {
-		$('windoweventsLinkCheck').addEvent('click', function(e) {
+	if ($('windoweventsLinkCheck')){
+		$('windoweventsLinkCheck').addEvent('click', function(e){
 			e.stop();
 			MUI.eventsWindow();
 		});
 	}
 
-	MUI.containerTestWindow = function() {
+	MUI.containerTestWindow = function(){
 		new MUI.Window({
 			id: 'containertest',
 			title: 'Container Test',
@@ -249,23 +265,25 @@ initializeWindows = function() {
 			y: 100
 		});
 	};
-	if ($('containertestLinkCheck')) {
-		$('containertestLinkCheck').addEvent('click', function(e) {
+	if ($('containertestLinkCheck')){
+		$('containertestLinkCheck').addEvent('click', function(e){
 			e.stop();
 			MUI.containerTestWindow();
 		});
 	}
 
-	MUI.iframeTestsWindow = function() {
+	MUI.iframeTestsWindow = function(){
 		new MUI.Window({
 			id: 'iframetests',
 			title: 'Iframe Tests',
-			loadMethod: 'iframe',
-			content: { url: 'pages/iframetests.html' }
+			content: {
+				url: 'pages/iframetests.html',
+				loadMethod: 'iframe'
+			}
 		});
 	};
-	if ($('iframetestsLinkCheck')) {
-		$('iframetestsLinkCheck').addEvent('click', function(e) {
+	if ($('iframetestLinkCheck')){
+		$('iframetestLinkCheck').addEvent('click', function(e){
 			e.stop();
 			MUI.iframeTestsWindow();
 		});
@@ -294,14 +312,14 @@ initializeWindows = function() {
 			maximizable: false
 		});
 	};
-	if ($('accordiantestLinkCheck')) {
-		$('accordiantestLinkCheck').addEvent('click', function(e) {
+	if ($('accordiantestLinkCheck')){
+		$('accordiantestLinkCheck').addEvent('click', function(e){
 			e.stop();
 			MUI.accordionTestWindow();
 		});
 	}
 
-	MUI.noCanvasWindow = function() {
+	MUI.noCanvasWindow = function(){
 		new MUI.Window({
 			id: 'nocanvas',
 			title: 'No Canvas',
@@ -315,51 +333,51 @@ initializeWindows = function() {
 			useCanvas: false
 		});
 	};
-	if ($('noCanvasLinkCheck')) {
-		$('noCanvasLinkCheck').addEvent('click', function(e) {
+	if ($('noCanvasLinkCheck')){
+		$('noCanvasLinkCheck').addEvent('click', function(e){
 			e.stop();
 			MUI.noCanvasWindow();
 		});
 	}
 
 	// View
-	if ($('sidebarLinkCheck')) {
-		$('sidebarLinkCheck').addEvent('click', function(e) {
+	if ($('sidebarLinkCheck')){
+		$('sidebarLinkCheck').addEvent('click', function(e){
 			e.stop();
 			MUI.Desktop.sidebarToggle();
 		});
 	}
 
-	if ($('cascadeLink')) {
-		$('cascadeLink').addEvent('click', function(e) {
+	if ($('cascadeLink')){
+		$('cascadeLink').addEvent('click', function(e){
 			e.stop();
 			MUI.Windows.arrangeCascade();
 		});
 	}
 
-	if ($('tileLink')) {
-		$('tileLink').addEvent('click', function(e) {
+	if ($('tileLink')){
+		$('tileLink').addEvent('click', function(e){
 			e.stop();
 			MUI.Windows.arrangeTile();
 		});
 	}
 
-	if ($('closeLink')) {
-		$('closeLink').addEvent('click', function(e) {
+	if ($('closeLink')){
+		$('closeLink').addEvent('click', function(e){
 			e.stop();
 			MUI.Windows.closeAll();
 		});
 	}
 
-	if ($('minimizeLink')) {
-		$('minimizeLink').addEvent('click', function(e) {
+	if ($('minimizeLink')){
+		$('minimizeLink').addEvent('click', function(e){
 			e.stop();
 			MUI.Windows.minimizeAll();
 		});
 	}
 
 	// Tools
-	MUI.builderWindow = function() {
+	MUI.builderWindow = function(){
 		new MUI.Window({
 			id: 'builder',
 			title: 'Window Builder',
@@ -371,15 +389,15 @@ initializeWindows = function() {
 			maximizable: false,
 			resizable: false,
 			scrollbars: false,
-			onDrawBegin: function() {
+			onDrawBegin: function(){
 				if ($('builderStyle')) return;
 				new Asset.css(MUI.replacePaths('{plugins}windowform/css/style.css'), {id: 'builderStyle'});
 			},
-			onLoaded: function() {
+			onLoaded: function(){
 				new Asset.javascript(MUI.replacePaths('{plugins}windowform/scripts/window-from-form.js'), {
 					id: 'builderScript',
-					onload: function() {
-						$('newWindowSubmit').addEvent('click', function(e) {
+					onload: function(){
+						$('newWindowSubmit').addEvent('click', function(e){
 							new Event(e).stop();
 							new MUI.WindowForm();
 						});
@@ -388,8 +406,8 @@ initializeWindows = function() {
 			}
 		});
 	};
-	if ($('builderLinkCheck')) {
-		$('builderLinkCheck').addEvent('click', function(e) {
+	if ($('builderLinkCheck')){
+		$('builderLinkCheck').addEvent('click', function(e){
 			e.stop();
 			MUI.builderWindow();
 		});
@@ -399,29 +417,29 @@ initializeWindows = function() {
 
 	// Workspaces
 
-	if ($('saveWorkspaceLink')) {
-		$('saveWorkspaceLink').addEvent('click', function(e) {
+	if ($('saveWorkspaceLink')){
+		$('saveWorkspaceLink').addEvent('click', function(e){
 			e.stop();
 			MUI.Desktop.saveWorkspace();
 		});
 	}
 
-	if ($('loadWorkspaceLink')) {
-		$('loadWorkspaceLink').addEvent('click', function(e) {
+	if ($('loadWorkspaceLink')){
+		$('loadWorkspaceLink').addEvent('click', function(e){
 			e.stop();
 			MUI.Desktop.loadWorkspace();
 		});
 	}
 
-	if ($('toggleStdEffectsLinkCheck')) {
-		$('toggleStdEffectsLinkCheck').addEvent('click', function(e) {
+	if ($('toggleStdEffectsLinkCheck')){
+		$('toggleStdEffectsLinkCheck').addEvent('click', function(e){
 			e.stop();
 			MUI.toggleStandardEffects($('toggleStdEffectsLinkCheck'));
 		});
 	}
 
-	if ($('toggleAdvEffectsLinkCheck')) {
-		$('toggleAdvEffectsLinkCheck').addEvent('click', function(e) {
+	if ($('toggleAdvEffectsLinkCheck')){
+		$('toggleAdvEffectsLinkCheck').addEvent('click', function(e){
 			e.stop();
 			MUI.toggleAdvancedEffects($('toggleAdvEffectsLinkCheck'));
 		});
@@ -441,7 +459,7 @@ initializeWindows = function() {
 				'position': 'top',
 				section: 'toolbar',
 				url: 'pages/features-tabs.html',
-				onLoaded: function() {
+				onLoaded: function(){
 					MUI.create('MUI.Tabs',{
 						'id':'features_toolbar',
 						'container':'features',
@@ -453,14 +471,14 @@ initializeWindows = function() {
 			}]
 		});
 	};
-	if ($('featuresLinkCheck')) {
-		$('featuresLinkCheck').addEvent('click', function(e) {
+	if ($('featuresLinkCheck')){
+		$('featuresLinkCheck').addEvent('click', function(e){
 			e.stop();
 			MUI.featuresWindow();
 		});
 	}
 
-	MUI.aboutWindow = function() {
+	MUI.aboutWindow = function(){
 		new MUI.Modal({
 			id: 'about',
 			addClass: 'about',
@@ -474,15 +492,15 @@ initializeWindows = function() {
 			scrollbars:  false
 		});
 	};
-	if ($('aboutLink')) {
-		$('aboutLink').addEvent('click', function(e) {
+	if ($('aboutLink')){
+		$('aboutLink').addEvent('click', function(e){
 			e.stop();
 			MUI.aboutWindow();
 		});
 	}
 
 	// Misc
-	MUI.authorsWindow = function() {
+	MUI.authorsWindow = function(){
 		new MUI.Modal({
 			id: 'authorsWindow',
 			title: 'AUTHORS.txt',
@@ -492,14 +510,14 @@ initializeWindows = function() {
 			scrollbars:true
 		});
 	};
-	if ($('authorsLink')) {
-		$('authorsLink').addEvent('click', function(e) {
+	if ($('authorsLink')){
+		$('authorsLink').addEvent('click', function(e){
 			new Event(e).stop();
 			MUI.authorsWindow();
 		});
 	}
 
-	MUI.licenseWindow = function() {
+	MUI.licenseWindow = function(){
 		new MUI.Modal({
 			id: 'License',
 			title: 'MIT-LICENSE.txt',
@@ -509,15 +527,15 @@ initializeWindows = function() {
 			scrollbars:true
 		});
 	};
-	if ($('licenseLink')) {
-		$('licenseLink').addEvent('click', function(e) {
+	if ($('licenseLink')){
+		$('licenseLink').addEvent('click', function(e){
 			new Event(e).stop();
 			MUI.licenseWindow();
 		});
 	}
 
 	// Deactivate menu header links
-	$$('a.returnFalse').addEvent('click', function(e) {
+	$$('a.returnFalse').addEvent('click', function(e){
 		e.stop();
 	});
 
@@ -531,17 +549,17 @@ initializeWindows = function() {
 MUI.initialize();
 
 // Initialize MochaUI when the DOM is ready
-window.addEvent('load', function() {
+window.addEvent('load', function(){
 
 	MUI.myChain = new Chain();
 	MUI.myChain.chain(
-			function() {
+			function(){
 				MUI.Desktop.initialize();
 			},
-			function() {
+			function(){
 				initializeWindows();
 			},
-			function() {
+			function(){
 				// force checkbox on menu to be in correct state
 				MUI.options.standardEffects = !MUI.options.standardEffects;
 				MUI.toggleStandardEffects($('toggleStdEffectsLinkCheck'));
@@ -553,12 +571,12 @@ window.addEvent('load', function() {
 			).callChain();
 
 	// This is just for the demo. Running it onload gives pngFix time to replace the pngs in IE6.
-	$$('.desktopIcon').addEvent('click', function() {
+	$$('.desktopIcon').addEvent('click', function(){
 		MUI.notification('Do Something');
 	});
 
 });
 
-window.addEvent('unload', function() {
+window.addEvent('unload', function(){
 	// This runs when a user leaves your page.
 });

--- a/Demo/scripts/demo-virtual-desktop-init.js
+++ b/Demo/scripts/demo-virtual-desktop-init.js
@@ -65,7 +65,7 @@ initializeWindows = function(){
 		new MUI.Window({
 			id: 'ajaxpage',
 			content: {
-				url:'pages/lipsum.html',
+				url: 'pages/lipsum.html',
 				loadMethod: 'xhr'
 			},
 			width: 340,
@@ -113,9 +113,9 @@ initializeWindows = function(){
 					section: 'toolbar',
 					loadMethod:'json',
 					content: [
-						{'text': 'Zero 7','url':'pages/youtube.html','title':'Zero 7'},
-						{'text': 'Fleet Foxes','url':'pages/youtube2.html','title':'Fleet Foxes'},
-						{'text': 'Boards of Canada','url':'pages/youtube3.html','title':'Boards of Canada'}
+						{'text': 'Zero 7', 'url': 'pages/youtube.html', 'title': 'Zero 7'},
+						{'text': 'Fleet Foxes', 'url': 'pages/youtube2.html', 'title': 'Fleet Foxes'},
+						{'text': 'Boards of Canada', 'url': 'pages/youtube3.html', 'title': 'Boards of Canada'}
 					],
 					onLoaded: function(element,uOptions,json){
 						MUI.create('MUI.Tabs',{
@@ -144,7 +144,7 @@ initializeWindows = function(){
 			title: 'Canvas Clock',
 			addClass: 'transparent',
 			content: {
-				url:'{plugins}coolclock/index.html',
+				url: '{plugins}coolclock/index.html',
 				loadMethod: 'xhr',
 				require: {
 					js: ['{plugins}coolclock/scripts/coolclock.js'],
@@ -191,7 +191,7 @@ initializeWindows = function(){
 			height: 210,
 			x: 230,
 			y: 180,
-			padding: { top: 12, right: 12, bottom: 10, left: 12 },
+			padding: {top: 12, right: 12, bottom: 10, left: 12},
 			resizable: false,
 			maximizable: false,
 			onDragStart: function(instance){
@@ -216,7 +216,7 @@ initializeWindows = function(){
 			id: 'windowevents',
 			title: 'Window Events',
 			loadMethod: 'xhr',
-			content: { url: 'pages/events.html' },
+			content: {url: 'pages/events.html'},
 			width: 340,
 			height: 250,
 			onLoaded: function(){
@@ -257,7 +257,7 @@ initializeWindows = function(){
 			id: 'containertest',
 			title: 'Container Test',
 			loadMethod: 'xhr',
-			content: { url: 'pages/lipsum.html' },
+			content: {url: 'pages/lipsum.html'},
 			container: 'pageWrapper',
 			width: 340,
 			height: 150,
@@ -299,9 +299,9 @@ initializeWindows = function(){
 				loadMethod: 'json',
 				onLoaded: function(el,cOptions,json){
 					MUI.create('MUI.Accordion',{
-						'container':id,
-						'idField':'value',
-						'panels':json
+						'container': id,
+						'idField': 'value',
+						'panels': json
 					});
 				}
 			},
@@ -324,7 +324,7 @@ initializeWindows = function(){
 			id: 'nocanvas',
 			title: 'No Canvas',
 			loadMethod: 'xhr',
-			content: { url:'pages/lipsum.html' },
+			content: {url: 'pages/lipsum.html'},
 			addClass: 'no-canvas',
 			width: 305,
 			height: 175,
@@ -383,7 +383,7 @@ initializeWindows = function(){
 			title: 'Window Builder',
 			icon: 'images/icons/page.gif',
 			loadMethod: 'xhr',
-			content: { url:'{plugins}windowform/' },
+			content: {url: '{plugins}windowform/'},
 			width: 370,
 			height: 410,
 			maximizable: false,
@@ -460,13 +460,13 @@ initializeWindows = function(){
 				section: 'toolbar',
 				url: 'pages/features-tabs.html',
 				onLoaded: function(){
-					MUI.create('MUI.Tabs',{
-						'id':'features_toolbar',
-						'container':'features',
+					MUI.create('MUI.Tabs', {
+						'id': 'features_toolbar',
+						'container': 'features',
 						'position': 'top',
-						'partner':'features',
-						'section':'toolbar'
-					},true);
+						'partner': 'features',
+						'section': 'toolbar'
+					}, true);
 				}
 			}]
 		});
@@ -484,12 +484,12 @@ initializeWindows = function(){
 			addClass: 'about',
 			title: 'MochaUI',
 			loadMethod: 'xhr',
-			content: { url:'pages/about.html' },
+			content: {url: 'pages/about.html'},
 			type: 'modal2',
 			width: 350,
 			height: 195,
-			padding: { top: 43, right: 12, bottom: 10, left: 12 },
-			scrollbars:  false
+			padding: {top: 43, right: 12, bottom: 10, left: 12},
+			scrollbars: false
 		});
 	};
 	if ($('aboutLink')){
@@ -504,10 +504,10 @@ initializeWindows = function(){
 		new MUI.Modal({
 			id: 'authorsWindow',
 			title: 'AUTHORS.txt',
-			content: { url:'scripts/AUTHORS.txt' },
+			content: {url: 'scripts/AUTHORS.txt'},
 			width: 400,
 			height: 250,
-			scrollbars:true
+			scrollbars: true
 		});
 	};
 	if ($('authorsLink')){
@@ -521,10 +521,10 @@ initializeWindows = function(){
 		new MUI.Modal({
 			id: 'License',
 			title: 'MIT-LICENSE.txt',
-			content: { url:'scripts/MIT-LICENSE.txt' },
+			content: {url:'scripts/MIT-LICENSE.txt'},
 			width: 580,
 			height: 350,
-			scrollbars:true
+			scrollbars: true
 		});
 	};
 	if ($('licenseLink')){

--- a/Demo/scripts/mocha-init.js
+++ b/Demo/scripts/mocha-init.js
@@ -129,7 +129,7 @@ var initializeWindows = function(){
 							'position': 'top',
 							'tabs': json,
 							'partner': 'youtube'
-						})
+						});
 					}
 				}
 			]
@@ -648,7 +648,7 @@ var initializeWindows = function(){
 			height: 250,
 			resizeLimit: {'x': [275, 2500], 'y': [125, 2000]},
 			content: [
-				{ url:'pages/features-layout.html' },
+				{url: 'pages/features-layout.html'},
 				{
 					position: 'top',
 					url: 'pages/features-tabs.html',
@@ -920,7 +920,7 @@ var initializeColumns = function(){
 		title: 'Lorem Ipsum',
 		column: 'mainColumn',
 		content: [
-			{ url:'pages/lipsum.html' },
+			{url:'pages/lipsum.html'},
 			{
 				position: 'headertool',
 				url: 'pages/toolbox-demo2.html',
@@ -1017,7 +1017,7 @@ var initializeColumns = function(){
 						'position': 'header',
 						'tabs': json,
 						'partner': 'help-panel'
-					})
+					}); 
 				}
 			}
 		]

--- a/Demo/scripts/mocha-init.js
+++ b/Demo/scripts/mocha-init.js
@@ -73,7 +73,7 @@ var initializeWindows = function(){
 	MUI.ajaxpageWindow = function(){
 		new MUI.Window({
 			id: 'ajaxpage',
-			content: { url:'pages/lipsum.html' },
+			content: {url: 'pages/lipsum.html'},
 			width: 340,
 			height: 150
 		});
@@ -110,24 +110,25 @@ var initializeWindows = function(){
 			content: [
 				{
 					url:'pages/youtube.html',
-					loadMethod: 'iframe'},
+					loadMethod: 'iframe'
+				},
 				{
 					position: 'top',
 					loadMethod:'json',
 					id: 'youtube_toolbar',
 					css: 'mochaToolbar',
 					content: [
-						{'text':'Zero 7','url':'pages/youtube.html','loadMethod':'iframe','title':'Zero 7'},
-						{'text':'Fleet Foxes','url':'pages/youtube2.html','loadMethod':'iframe','title':'Fleet Foxes'},
-						{'text':'Boards of Canada','url':'pages/youtube3.html','loadMethod':'iframe','title':'Boards of Canada'}
+						{'text': 'Zero 7', 'url': 'pages/youtube.html', 'loadMethod': 'iframe', 'title': 'Zero 7'},
+						{'text': 'Fleet Foxes', 'url': 'pages/youtube2.html', 'loadMethod': 'iframe', 'title': 'Fleet Foxes'},
+						{'text': 'Boards of Canada', 'url': 'pages/youtube3.html', 'loadMethod': 'iframe', 'title': 'Boards of Canada'}
 					],
 					onLoaded: function(element, uOptions, json){
 						MUI.create('MUI.Tabs', {
-							'id':'youtube_toolbar',
-							'container':'youtube',
+							'id': 'youtube_toolbar',
+							'container': 'youtube',
 							'position': 'top',
-							'tabs':json,
-							'partner':'youtube'
+							'tabs': json,
+							'partner': 'youtube'
 						})
 					}
 				}
@@ -147,7 +148,7 @@ var initializeWindows = function(){
 			title: 'Canvas Clock',
 			addClass: 'transparent',
 			content: {
-				url:'{plugins}coolclock/index.html',
+				url: '{plugins}coolclock/index.html',
 				require: {
 				js: ['{plugins}coolclock/scripts/coolclock.js'],
 				onload: function(){
@@ -175,7 +176,7 @@ var initializeWindows = function(){
 			id: 'parametrics',
 			title: 'Window Parametrics',
 			content: {
-				url:'{plugins}parametrics/index.html',
+				url: '{plugins}parametrics/index.html',
 				require: {
 					css: ['{plugins}parametrics/css/style.css'],
 					js: ['{plugins}parametrics/scripts/parametrics.js'],
@@ -241,7 +242,7 @@ var initializeWindows = function(){
 				new MUI.Panel({
 					header: false,
 					id: 'splitWindow_panel1',
-					content: { url:'license.html'},
+					content: {url: 'license.html'},
 					column: 'splitWindow_mainColumn',
 					panelBackground: '#fff'
 				});
@@ -250,7 +251,7 @@ var initializeWindows = function(){
 					header: false,
 					id: 'splitWindow_panel2',
 					addClass: 'panelAlt',
-					content: { url:'pages/lipsum.html' },
+					content: {url: 'pages/lipsum.html'},
 					column: 'splitWindow_sideColumn'
 				});
 
@@ -347,7 +348,7 @@ var initializeWindows = function(){
 		new MUI.Window({
 			id: 'containertest',
 			title: 'Container Test',
-			content: { url:'pages/lipsum.html' },
+			content: {url: 'pages/lipsum.html'},
 			container: 'pageWrapper',
 			width: 340,
 			height: 150,
@@ -367,7 +368,7 @@ var initializeWindows = function(){
 			id: 'iframetests',
 			title: 'Iframe Tests',
 			content: {
-				url:'pages/iframetests.html', 
+				url: 'pages/iframetests.html', 
 				loadMethod: 'iframe'
 			}
 		});
@@ -383,7 +384,7 @@ var initializeWindows = function(){
 		new MUI.Window({
 			id: 'formtests',
 			title: 'Form Tests',
-			content: { url:'pages/formtests.html' },
+			content: {url: 'pages/formtests.html'},
 			onLoaded: function(){
 				document.testForm.focusTest.focus();
 			}
@@ -401,18 +402,17 @@ var initializeWindows = function(){
 		new MUI.Window({
 			id: id,
 			title: 'Accordion',
-			content: { url:'pages/accordion-demo.json', loadMethod: 'json' },
+			content: {url: 'pages/accordion-demo.json', loadMethod: 'json'},
 			width: 300,
 			height: 200,
 			scrollbars: false,
 			resizable: false,
 			maximizable: false,
-
 			onLoaded: function(el, cOptions, json){
 				MUI.create('MUI.Accordion', {
-					'container':id,
-					'idField':'value',
-					'panels':json
+					'container': id,
+					'idField': 'value',
+					'panels': json
 				});
 			}
 		});
@@ -428,7 +428,7 @@ var initializeWindows = function(){
 		new MUI.Window({
 			id: 'nocanvas',
 			title: 'No Canvas',
-			content: { url:'pages/lipsum.html' },
+			content: {url: 'pages/lipsum.html'},
 			addClass: 'no-canvas',
 			width: 305,
 			height: 175,
@@ -449,7 +449,7 @@ var initializeWindows = function(){
 		new MUI.Window({
 			id: 'css3',
 			title: 'CSS3',
-			content: { url:'pages/lipsum.html' },
+			content: {url: 'pages/lipsum.html'},
 			addClass: 'no-canvas',
 			width: 305,
 			height: 175,
@@ -469,7 +469,7 @@ var initializeWindows = function(){
 		new MUI.Window({
 			id: 'css3fallback',
 			title: 'CSS3 with Fallback to Canvas',
-			content: { url:'pages/lipsum.html' },
+			content: {url: 'pages/lipsum.html'},
 			width: 305,
 			height: 175,
 			resizable: false,
@@ -488,7 +488,7 @@ var initializeWindows = function(){
 		new MUI.Window({
 			id: 'forceCanvas',
 			title: 'Force Canvas',
-			content: { url:'pages/lipsum.html' },
+			content: {url: 'pages/lipsum.html'},
 			width: 305,
 			height: 175,
 			resizable: false,
@@ -572,7 +572,7 @@ var initializeWindows = function(){
 			title: 'Window Builder',
 			icon: 'images/icons/16x16/page.gif',
 			content: {
-				url:'{plugins}windowform/',
+				url: '{plugins}windowform/',
 				require: {
 					css: ['{plugins}windowform/css/style.css'],
 					js: ['{plugins}windowform/scripts/window-from-form.js'],
@@ -654,10 +654,10 @@ var initializeWindows = function(){
 					url: 'pages/features-tabs.html',
 					onLoaded: function(){
 						MUI.create('MUI.Tabs', {
-							'id':'features_toolbar',
-							'container':'features',
+							'id': 'features_toolbar',
+							'container': 'features',
 							'position': 'top',
-							'partner':'features'
+							'partner': 'features'
 						}, true);
 					}
 				}
@@ -675,7 +675,7 @@ var initializeWindows = function(){
 		new MUI.Modal({
 			id: 'about',
 			title: 'MUI',
-			content: { url:'pages/about.html' },
+			content: {url: 'pages/about.html'},
 			type: 'modal2',
 			width: 350,
 			height: 195,
@@ -695,7 +695,7 @@ var initializeWindows = function(){
 		new MUI.Modal({
 			id: 'authorsWindow',
 			title: 'AUTHORS.txt',
-			content: { url:'scripts/AUTHORS.txt' },
+			content: {url: 'scripts/AUTHORS.txt'},
 			width: 400,
 			height: 250,
 			scrollbars: true
@@ -712,7 +712,7 @@ var initializeWindows = function(){
 		new MUI.Modal({
 			id: 'License',
 			title: 'MIT-LICENSE.txt',
-			content: { url:'scripts/MIT-LICENSE.txt' },
+			content: {url: 'scripts/MIT-LICENSE.txt'},
 			width: 580,
 			height: 350,
 			scrollbars: true
@@ -785,14 +785,14 @@ var initializeColumns = function(){
 		id: 'files-panel',
 		title: 'Examples',
 		content: {
-			url:'pages/file-tree.json',
-			loadMethod:'json',
+			url: 'pages/file-tree.json',
+			loadMethod: 'json',
 			onLoaded: function(el, options, json){
 				MUI.create('MUI.Tree', {
-					'container':'files-panel',
-					'idField':'value',
-					'nodes':options.content,
-					"onLoaded": function(){
+					'container': 'files-panel',
+					'idField': 'value',
+					'nodes': options.content,
+					'onLoaded': function(){
 						$('notesLink').addEvent('click', function(){
 							MUI.Content.update({
 								element: $('mainPanel'),
@@ -853,7 +853,7 @@ var initializeColumns = function(){
 									css: ['{controls}calendar/style.css'],
 									js: ['{controls}calendar/calendar.js'],
 									onload: function(){
-										new Calendar({ date1: 'd/m/Y' }, { direction: 1, tweak: {x: 6, y: 0}});
+										new Calendar({date1: 'd/m/Y'}, {direction: 1, tweak: {x: 6, y: 0}});
 									}
 								}
 							});
@@ -1008,15 +1008,15 @@ var initializeColumns = function(){
 				empty: true,
 				loadMethod:'json',
 				content: [
-					{'text':'Overview','url':'pages/overview.html','title':'Overview'},
-					{'text':'Download','url':'pages/download.html','title':'Download'}
+					{'text': 'Overview', 'url': 'pages/overview.html', 'title': 'Overview'},
+					{'text': 'Download', 'url': 'pages/download.html', 'title': 'Download'}
 				],
 				onLoaded: function(element, uOptions, json){
 					MUI.create('MUI.Tabs', {
-						'container':'help-panel',
+						'container': 'help-panel',
 						'position': 'header',
-						'tabs':json,
-						'partner':'help-panel'
+						'tabs': json,
+						'partner': 'help-panel'
 					})
 				}
 			}
@@ -1027,7 +1027,7 @@ var initializeColumns = function(){
 		id: 'panel3',
 		title: 'Panel',
 		content: {
-			url:'pages/lipsum.html',
+			url: 'pages/lipsum.html',
 			onLoaded: addResizeElements
 		},
 		column: 'sideColumn2',
@@ -1041,7 +1041,7 @@ var initializeColumns = function(){
 		column: 'sideColumn2',
 		height: 140,
 		content: [
-			{ url:'pages/tips.html' },
+			{url: 'pages/tips.html'},
 			{
 				position: 'footer',
 				url: 'pages/toolbox-demo.html',
@@ -1075,7 +1075,7 @@ var initializeColumns = function(){
 			new MUI.Panel({
 				header: false,
 				id: 'splitPanel_mainPanel',
-				content: {url:'license.html'},
+				content: {url: 'license.html'},
 				column: 'mainColumn2'
 			});
 
@@ -1083,7 +1083,7 @@ var initializeColumns = function(){
 				header: false,
 				id: 'splitPanel_sidePanel',
 				addClass: 'panelAlt',
-				content: {url:'pages/lipsum.html'},
+				content: {url: 'pages/lipsum.html'},
 				column: 'sideColumn3'
 			});
 		}
@@ -1099,14 +1099,14 @@ MUI.initialize();
 window.addEvent('load', function(){ //using load instead of domready for IE8
 	MUI.myChain = new Chain();
 	MUI.myChain.chain(
-			function(){
-				MUI.Desktop.initialize();
-			},
-			function(){
-				initializeColumns();
-			},
-			function(){
-				initializeWindows();
-			}
-			).callChain();
+		function(){
+			MUI.Desktop.initialize();
+		},
+		function(){
+			initializeColumns();
+		},
+		function(){
+			initializeWindows();
+		}
+	).callChain();
 });

--- a/Demo/scripts/mocha-init.js
+++ b/Demo/scripts/mocha-init.js
@@ -1002,7 +1002,6 @@ var initializeColumns = function(){
 		id: 'help-panel',
 		column: 'sideColumn2',
 		content: [
-			{url:'pages/overview.html'},
 			{
 				position: 'header',
 				empty: true,

--- a/Source/Core/Column.js
+++ b/Source/Core/Column.js
@@ -59,9 +59,9 @@ MUI.Column = new NamedClass('MUI.Column', {
 		if (this.options.drawOnInit) this.draw();
 	},
 
-	draw: function() {
+	draw: function(){
 		var options = this.options;
-		this.fireEvent('drawBegin',[this]);
+		this.fireEvent('drawBegin', [this]);
 
 		if (options.container == null) options.container = MUI.Desktop.pageWrapper;
 		else $(options.container).setStyle('overflow', 'hidden');
@@ -167,15 +167,15 @@ MUI.Column = new NamedClass('MUI.Column', {
 		}
 
 		MUI.rWidth();
-		this.fireEvent('drawEnd',[this]);
+		this.fireEvent('drawEnd', [this]);
 		return this;
 	},
 
 	getPanels: function(){
-		var panels=[];
-		$(this.el.column).getElements('.panel').each(function(panelEl) {
-			var panel=MUI.get(panelEl.id);
-			if(panel) panels.push(panel);
+		var panels = [];
+		$(this.el.column).getElements('.panel').each(function(panelEl){
+			var panel = MUI.get(panelEl.id);
+			if (panel) panels.push(panel);
 		});
 		return panels;
 	},
@@ -197,7 +197,7 @@ MUI.Column = new NamedClass('MUI.Column', {
 		column.addClass('collapsed');
 		column.removeClass('expanded');
 		MUI.rWidth();
-		this.fireEvent('collapse',[this]);
+		this.fireEvent('collapse', [this]);
 
 		return this;
 	},
@@ -218,7 +218,7 @@ MUI.Column = new NamedClass('MUI.Column', {
 		this.el.handle.setStyle('cursor', Browser.Engine.webkit ? 'col-resize' : 'e-resize').addClass('attached');
 
 		MUI.rWidth();
-		this.fireEvent('expand',[this]);
+		this.fireEvent('expand', [this]);
 
 		return this;
 	},

--- a/Source/Core/Content.js
+++ b/Source/Core/Content.js
@@ -51,7 +51,7 @@ MUI.Content = (MUI.Content || $H({})).extend({
 			css: []		// the style sheets to load before the request is made
 			, images: []	// the images to preload before the request is made
 			, js: []		// the JavaScript that is loaded and called after the request is made
-			, onload: null	// the event that is fired after all required files are loaded
+			, onload: $empty // the event that is fired after all required files are loaded
 		}, options.require);
 
 		// set defaults for paging

--- a/Source/Core/Content.js
+++ b/Source/Core/Content.js
@@ -281,7 +281,7 @@ MUI.Content.Providers.xhr = {
 		var fireLoaded = options.fireLoaded;
 		
 		// if js is required, but no url, fire loaded to proceed with js-only
-		if (options.url == null && options.require.length != 0){
+		if (options.url == null && options.require.js && options.require.js.length != 0){
 			Browser.Engine.trident4 ? fireLoaded.delay(50, this, [instance, options]) : fireLoaded(instance, options);
 			return null;
 		}

--- a/Source/Core/Content.js
+++ b/Source/Core/Content.js
@@ -280,6 +280,12 @@ MUI.Content.Providers.xhr = {
 		var contentContainer = options.contentContainer;
 		var fireLoaded = options.fireLoaded;
 
+		// if js is required, but no url, fire loaded to proceed with js-only
+		if (options.url == null && options.require.length != 0){
+			Browser.Engine.trident4 ? fireLoaded.delay(50, this, [instance, options]) : fireLoaded(instance, options);
+			return null;
+		}
+
 		// load persisted data if it exists
 		var content = options.persistLoad(options);
 

--- a/Source/Core/Content.js
+++ b/Source/Core/Content.js
@@ -21,9 +21,9 @@ MUI.files['{source}Core/Content.js'] = 'loaded';
 
 MUI.Content = (MUI.Content || $H({})).extend({
 
-	Providers:{},
+	Providers: {},
 
-	Filters:{},
+	Filters: {},
 
 	update: function(options){
 
@@ -77,7 +77,7 @@ MUI.Content = (MUI.Content || $H({})).extend({
 		}
 
 		var element,instance = options.instance;
-		if (options.element) {
+		if (options.element){
 			element = $(options.element);
 			if (!instance) instance = element.retrieve('instance');
 		}
@@ -87,7 +87,7 @@ MUI.Content = (MUI.Content || $H({})).extend({
 			// create standard field replacements from data, paging, and path hashes
 			var values = $H({}).combine(options.data).combine(options.paging).combine(MUI.options.path);
 			// call the prepUrl callback if it was defined
-			if (options.prepUrl) options.url = options.prepUrl.run([options.url,values,instance], this);
+			if (options.prepUrl) options.url = options.prepUrl.run([options.url, values, instance], this);
 			options.url = MUI.replaceFields(options.url, values);
 		}
 
@@ -155,7 +155,7 @@ MUI.Content = (MUI.Content || $H({})).extend({
 							if (options.onLoaded && options.onLoaded != $empty){
 								options.onLoaded(element, options, json)
 							} else {
-								if (instance) instance.fireEvent('loaded', [element,options,json]);
+								if (instance) instance.fireEvent('loaded', [element, options, json]);
 							}
 						}.bind(this)
 					});
@@ -165,7 +165,7 @@ MUI.Content = (MUI.Content || $H({})).extend({
 						options.onLoaded(element, options, json)
 					} else {
 						// fire the event
-						if (instance) instance.fireEvent('loaded', [element,options,json]);
+						if (instance) instance.fireEvent('loaded', [element, options, json]);
 					}
 				}
 			}
@@ -279,7 +279,7 @@ MUI.Content.Providers.xhr = {
 	doRequest: function(instance, options){
 		var contentContainer = options.contentContainer;
 		var fireLoaded = options.fireLoaded;
-
+		
 		// if js is required, but no url, fire loaded to proceed with js-only
 		if (options.url == null && options.require.length != 0){
 			Browser.Engine.trident4 ? fireLoaded.delay(50, this, [instance, options]) : fireLoaded(instance, options);
@@ -295,7 +295,7 @@ MUI.Content.Providers.xhr = {
 			Browser.Engine.trident4 ? fireLoaded.delay(50, this, [instance, options, content]) : fireLoaded(instance, options, content);
 			return;
 		}
-
+		
 		new Request({
 			url: options.url,
 			method: options.method ? options.method : 'get',
@@ -347,6 +347,7 @@ MUI.Content.Providers.xhr = {
 			onComplete: function(){
 			}
 		}).send();
+	
 	}
 
 };
@@ -493,7 +494,7 @@ MUI.extend({
 					if ($type(options.padding) != 'number')
 						options.padding = $extend(options, this.options.padding);
 					if ($type(options.padding) == 'number')
-						options.padding = {top:options.padding,left:options.padding,right:options.padding,bottom:options.padding};
+						options.padding = {top: options.padding, left: options.padding, right: options.padding, bottom: options.padding};
 
 					// update padding if requested
 					this.el.content.setStyles({

--- a/Source/Core/Core.js
+++ b/Source/Core/Core.js
@@ -29,7 +29,7 @@
 var MochaUI;
 var MUI = MochaUI = (MUI || {});
 
-MUI.extend = function(hash) {
+MUI.extend = function(hash){
 	$extend(MUI,hash);
 }.bind(MUI);
 
@@ -68,19 +68,19 @@ MUI.extend({
 
 		if ($type(str) == 'string'){
 			var keys = str.match(/\{+(\w*)\}+/g);
-			if(keys==null) return str;
+			if (keys == null) return str;
 
 			keys.each(function(key){
-				var name=key.replace(/[\{\}]/g,"");
-				if (name==null || name=='') return;
+				var name = key.replace(/[\{\}]/g, '');
+				if (name == null || name == '') return;
 
-				var re = new RegExp("\\{"+name+"\\}","g");
+				var re = new RegExp('\\{' + name + '\\}', 'g');
 				str = str.replace(re,values[name]);
 			});
 			return str;
 		}
 		if ($type(str) == 'array'){
-			for(var i = 0; i < str.length; i++){
+			for (var i = 0; i < str.length; i++){
 				str[i] = MUI.replaceFields(str[i]);
 			}
 		}
@@ -125,11 +125,11 @@ MUI.extend({
 	},
 
 	create:function(type,options,fromHTML){
-		if(MUI.files['{controls}mui-controls.js'] != 'loaded') {
+		if (MUI.files['{controls}mui-controls.js'] != 'loaded'){
 			new MUI.Require({
 				'js':['{controls}mui-controls.js'],
-				'onload':function() {
-					MUI.create(type,options);
+				'onload':function(){
+					MUI.create(type, options);
 				}
 			});
 			return;
@@ -137,29 +137,29 @@ MUI.extend({
 
 		var name=type.replace(/(^MUI\.)/i,'');
 		var sname=name.toLowerCase();
-		if(MUI.classes[sname]==null) return null;
+		if (MUI.classes[sname] == null) return null;
 
-		var js=['{controls}'+sname+'/'+sname+'.js'];
+		var js=['{controls}' + sname + '/' + sname + '.js'];
 
-		if(MUI.files[js[0]]=='loaded' && !fromHTML) {
-			var klass=MUI[name];
+		if (MUI.files[js[0]] == 'loaded' && !fromHTML){
+			var klass = MUI[name];
 			return new klass(options);
 		}
 
-		if(fromHTML) js.push('{controls}'+sname+'/'+sname+'_html.js');
+		if (fromHTML) js.push('{controls}' + sname + '/' + sname + '_html.js');
 
-		var additionalOptions=MUI.classes[sname];
-		var css=[];
-		if(additionalOptions.css) css=additionalOptions.css;
+		var additionalOptions = MUI.classes[sname];
+		var css = [];
+		if (additionalOptions.css) css = additionalOptions.css;
 
 		var ret;
 		new MUI.Require({
 			'js':js,
 			'css':css,
-			'onload':function() {
-				var klass=MUI[name];
+			'onload':function(){
+				var klass = MUI[name];
 				ret = new klass(options);
-				if(fromHTML) ret.fromHTML();
+				if (fromHTML) ret.fromHTML();
 			}
 		});
 		return ret;

--- a/Source/Core/Desktop.js
+++ b/Source/Core/Desktop.js
@@ -44,7 +44,7 @@ MUI.Desktop = {
 	initialize: function(options){
 		if (options) $extend(MUI.Desktop.options,options);
 
-		if(MUI.desktop) return;	// only one desktop allowed
+		if (MUI.desktop) return;	// only one desktop allowed
 		MUI.desktop = this;
 
 		this.desktop = $(this.options.desktop);
@@ -66,8 +66,8 @@ MUI.Desktop = {
 			});
 		}
 
-		if(!this.options.dockOptions.container) this.options.dockOptions.container = this.desktop;
-		if(this.options.createDock) this.dock=new MUI.Dock(this.options.dockOptions);
+		if (!this.options.dockOptions.container) this.options.dockOptions.container = this.desktop;
+		if (this.options.createDock) this.dock = new MUI.Dock(this.options.dockOptions);
 		if (!this.dock) this.setDesktopSize();  // This is run on dock initialize so no need to do it twice.
 		this._menuInitialize();
 
@@ -109,11 +109,11 @@ MUI.Desktop = {
 		MUI.rWidth();
 	},
 
-	saveWorkspace: function() {
+	saveWorkspace: function(){
 		this.cookie = new Hash.Cookie('mochaUIworkspaceCookie', {duration: 3600});
 		this.cookie.empty();
 
-		MUI.each(function(instance) {
+		MUI.each(function(instance){
 			if (instance.className != 'MUI.Window') return;
 			instance._saveValues();
 			this.cookie.set(instance.options.id, {
@@ -135,22 +135,22 @@ MUI.Desktop = {
 			width: 200,
 			height: 40,
 			y: 53,
-			padding: { top: 10, right: 12, bottom: 10, left: 12 },
+			padding: {top: 10, right: 12, bottom: 10, left: 12},
 			shadowBlur: 5
 		});
 	},
 
-	loadingCallChain: function() {
-		if ($$('.mocha').length == 0 && this.myChain) {
+	loadingCallChain: function(){
+		if ($$('.mocha').length == 0 && this.myChain){
 			this.myChain.callChain();
 		}
 	},
 
-	loadWorkspace: function() {
+	loadWorkspace: function(){
 		var cookie = new Hash.Cookie('mochaUIworkspaceCookie', {duration: 3600});
 		var workspaceWindows = cookie.load();
 
-		if (!cookie.getKeys().length) {
+		if (!cookie.getKeys().length){
 			new MUI.Window({
 				loadMethod: 'html',
 				type: 'notification',
@@ -160,14 +160,14 @@ MUI.Desktop = {
 				width: 220,
 				height: 40,
 				y: 25,
-				padding: { top: 10, right: 12, bottom: 10, left: 12 },
+				padding: {top: 10, right: 12, bottom: 10, left: 12},
 				shadowBlur: 5
 			});
 			return;
 		}
 
-		var doLoadWorkspace = (function(workspaceWindows) {
-			workspaceWindows.each(function(workspaceWindow) {
+		var doLoadWorkspace = (function(workspaceWindows){
+			workspaceWindows.each(function(workspaceWindow){
 				windowFunction = MUI[workspaceWindow.id + 'Window'];
 				if (windowFunction) windowFunction();
 				// currently disabled positioning of windows, that would need to be passed to the MUI.Window call
@@ -192,12 +192,12 @@ MUI.Desktop = {
 			this.loadingWorkspace = false;
 		}).bind(this);
 
-		if ($$('.mocha').length != 0) {
+		if ($$('.mocha').length != 0){
 			this.loadingWorkspace = true;
 			this.myChain = new Chain();
 			this.myChain.chain(
-					function() {
-						$$('.mocha').each(function(el) {
+					function(){
+						$$('.mocha').each(function(el){
 							el.close();
 						});
 						this.myChain.callChain();
@@ -227,7 +227,7 @@ MUI.Desktop = {
 		// Resize maximized windows to fit new browser window size
 		setTimeout(function(){
 			MUI.each(function(instance){
-				var options=instance.options;
+				var options = instance.options;
 				if (instance.className != 'MUI.Window') return;
 				if (instance.isMaximized){
 
@@ -235,7 +235,7 @@ MUI.Desktop = {
 					if (instance.el.iframe) instance.el.iframe.setStyle('visibility', 'hidden');
 
 					var resizeDimensions;
-					if(options.container) resizeDimensions=$(options.container).getCoordinates();
+					if (options.container) resizeDimensions = $(options.container).getCoordinates();
 					else resizeDimensions=document.getCoordinates();
 					var shadowBlur = options.shadowBlur;
 					var shadowOffset = options.shadowOffset;
@@ -303,8 +303,7 @@ MUI.Windows = (MUI.Windows || $H({})).extend({
 						'top': y,
 						'left': x
 					});
-				}
-				else {
+				} else {
 					var cascadeMorph = new Fx.Morph(windowEl, {
 						'duration': 550
 					});
@@ -379,7 +378,7 @@ MUI.Windows = (MUI.Windows || $H({})).extend({
 	}
 });
 
-MUI.Window = (MUI.Window || new NamedClass('MUI.Window',{})).implement({
+MUI.Window = (MUI.Window || new NamedClass('MUI.Window', {})).implement({
 
 	maximize: function(){
 		if (this.isMinimized) this._restoreMinimized();

--- a/Source/Core/Dock.js
+++ b/Source/Core/Dock.js
@@ -47,22 +47,22 @@ MUI.Dock = (MUI.Dock || new NamedClass('MUI.Dock',{})).implement({
 	initialize: function(options){
 		this.setOptions(options);
 
-		if (MUI.dock!=null) return false;  // only one dock allowed
+		if (MUI.dock != null) return false;  // only one dock allowed
 		else MUI.set(this.options.id, this);
 		MUI.dock = this;
 
-		if(!this.options.container) this.options.container = 'desktop';
+		if (!this.options.container) this.options.container = 'desktop';
 		this.container = $(this.options.container);
 
 		this.el = {};
 		this.el.dock = $(this.options.id);
-		if(!this.el.dock && this.options.drawOnInit) this.draw();
-		else if(this.el.dock) {
-			this.el.wrapper = $(this.options.id+'Wrapper');
+		if (!this.el.dock && this.options.drawOnInit) this.draw();
+		else if (this.el.dock){
+			this.el.wrapper = $(this.options.id + 'Wrapper');
 
 			if (!this.options.useControls){
-				if ($(this.options.id+'Placement')) $(this.options.id+'Placement').setStyle('cursor', 'default');
-				if ($(this.options.id+'AutoHide')) $(this.options.id+'AutoHide').setStyle('cursor', 'default');
+				if ($(this.options.id + 'Placement')) $(this.options.id + 'Placement').setStyle('cursor', 'default');
+				if ($(this.options.id + 'AutoHide')) $(this.options.id + 'AutoHide').setStyle('cursor', 'default');
 			}
 
 			this.el.wrapper.setStyles({
@@ -77,28 +77,28 @@ MUI.Dock = (MUI.Dock || new NamedClass('MUI.Dock',{})).implement({
 		}
 	},
 
-	draw: function() {
-		this.fireEvent('drawBegin',[this]);
+	draw: function(){
+		this.fireEvent('drawBegin', [this]);
 
-		this.el.wrapper = new Element('div',{'id':this.options.id+'Wrapper',styles:{
+		this.el.wrapper = new Element('div', {'id': this.options.id + 'Wrapper', styles: {
 				'display':	'block',
 				'position':	'absolute',
 				'top':		null,
 				'bottom':	MUI.Desktop.desktopFooter ? MUI.Desktop.desktopFooter.offsetHeight : 0,
 				'left':		0
 			}}).inject(this.container);
-		this.el.dock = new Element('div',{'id':this.options.id}).inject(this.el.wrapper);
+		this.el.dock = new Element('div', {'id': this.options.id}).inject(this.el.wrapper);
 
 		if (this.options.useControls){
-			this.el.dockPlacement = new Element('div',{'id':this.options.id+'Placement'}).inject(this.el.dock).setStyle('cursor', 'default');
-			this.el.dockAutoHide = new Element('div',{'id':this.options.id+'AutoHide'}).inject(this.el.dock).setStyle('cursor', 'default');
+			this.el.dockPlacement = new Element('div', {'id': this.options.id + 'Placement'}).inject(this.el.dock).setStyle('cursor', 'default');
+			this.el.dockAutoHide = new Element('div', {'id': this.options.id + 'AutoHide'}).inject(this.el.dock).setStyle('cursor', 'default');
 		}
 
-		this.el.dockSort = new Element('div',{'id':this.options.id+'Sort'}).inject(this.el.dock);
-		this.el.dockClear = new Element('div',{'id':this.options.id+'Clear','class':'clear'}).inject(this.el.dockSort);
+		this.el.dockSort = new Element('div', {'id': this.options.id + 'Sort'}).inject(this.el.dock);
+		this.el.dockClear = new Element('div', {'id': this.options.id + 'Clear', 'class': 'clear'}).inject(this.el.dockSort);
 
 		this._initializeDockControls();
-		this.fireEvent('drawEnd',[this]);
+		this.fireEvent('drawEnd', [this]);
 	},
 
 	setDockColors: function(){
@@ -117,7 +117,7 @@ MUI.Dock = (MUI.Dock || new NamedClass('MUI.Dock',{})).implement({
 		this._renderDockControls();
 	},
 
-	getHeight: function() {
+	getHeight: function(){
 		return this.el.wrapper.offsetHeight;
 	},
 
@@ -136,8 +136,8 @@ MUI.Dock = (MUI.Dock || new NamedClass('MUI.Dock',{})).implement({
 			ctx.clearRect(0, 0, 100, 100);
 			MUI.Canvas.circle(ctx, 5, 4, 3, this.enabledButtonColor, 1.0);
 			MUI.Canvas.circle(ctx, 5, 14, 3, this.disabledButtonColor, 1.0);
-			$(this.options.id+'Placement').setProperty('title', 'Position Dock Bottom');
-			$(this.options.id+'AutoHide').setProperty('title', 'Auto Hide Disabled in Top Dock Position');
+			$(this.options.id + 'Placement').setProperty('title', 'Position Dock Bottom');
+			$(this.options.id + 'AutoHide').setProperty('title', 'Auto Hide Disabled in Top Dock Position');
 			this.options.autoHide = false;
 			this.options.position = 'top';
 		} else {
@@ -153,12 +153,12 @@ MUI.Dock = (MUI.Dock || new NamedClass('MUI.Dock',{})).implement({
 			ctx.clearRect(0, 0, 100, 100);
 			MUI.Canvas.circle(ctx, 5, 4, 3, this.enabledButtonColor, 1.0);
 			MUI.Canvas.circle(ctx, 5, 14, 3, this.enabledButtonColor, 1.0);
-			$(this.options.id+'Placement').setProperty('title', 'Position Dock Top');
-			$(this.options.id+'AutoHide').setProperty('title', 'Turn Auto Hide On');
+			$(this.options.id + 'Placement').setProperty('title', 'Position Dock Top');
+			$(this.options.id + 'AutoHide').setProperty('title', 'Turn Auto Hide On');
 			this.options.position = 'bottom';
 		}
 
-		this.fireEvent('move',[this,this.options.position]);
+		this.fireEvent('move', [this, this.options.position]);
 	},
 
 	createDockTab: function(instance){
@@ -166,7 +166,7 @@ MUI.Dock = (MUI.Dock || new NamedClass('MUI.Dock',{})).implement({
 			'id': instance.options.id + '_dockTab',
 			'class': 'dockTab',
 			'title': titleText
-		}).inject($(this.options.id+'Clear'), 'before');
+		}).inject($(this.options.id + 'Clear'), 'before');
 
 		dockTab.addEvent('mousedown', function(e){
 			new Event(e).stop();
@@ -179,15 +179,15 @@ MUI.Dock = (MUI.Dock || new NamedClass('MUI.Dock',{})).implement({
 				// If the visibility of the windows on the page are toggled off, toggle visibility on.
 				if (!MUI.Windows.windowsVisible){
 					MUI.Windows.toggleAll();
-					if (this.isMinimized) this._restoreMinimized.delay(25,this);
+					if (this.isMinimized) this._restoreMinimized.delay(25, this);
 					else this.focus();
 					return;
 				}
 				// If window is minimized, restore window.
-				if (this.isMinimized) this._restoreMinimized.delay(25,this);
+				if (this.isMinimized) this._restoreMinimized.delay(25, this);
 				else {
 					var windowEl = this.el.windowEl;
-					if (windowEl.hasClass('isFocused') && this.options.minimizable) this.minimize.delay(25,this);
+					if (windowEl.hasClass('isFocused') && this.options.minimizable) this.minimize.delay(25, this);
 					else this.focus();
 
 					// if the window is not minimized and is outside the viewport, center it in the viewport.
@@ -209,11 +209,11 @@ MUI.Dock = (MUI.Dock || new NamedClass('MUI.Dock',{})).implement({
 
 		// Need to resize everything in case the dock wraps when a new tab is added
 		MUI.Desktop.setDesktopSize();
-		this.fireEvent('tabCreated',[this,instance]);
+		this.fireEvent('tabCreated', [this, instance]);
 	},
 
 	makeActiveTab: function(instance){
-		if(!instance) {
+		if (!instance){
 			// getWindowWithHighestZindex is used in case the currently focused window is closed.
 			var windowEl = MUI.Windows._getWithHighestZIndex();
 			instance = windowEl.retrieve('instance');
@@ -228,14 +228,14 @@ MUI.Dock = (MUI.Dock || new NamedClass('MUI.Dock',{})).implement({
 		this.fireEvent('tabSet',[this,instance]);
 	},
 
-	show: function() {
+	show: function(){
 		this.el.wrapper.show();
 		this.options.visible = true;
 		MUI.Desktop.setDesktopSize();
 		this.fireEvent('show',[this]);
 	},
 
-	hide: function() {
+	hide: function(){
 		this.el.wrapper.hide();
 		this.options.visible = false;
 		MUI.Desktop.setDesktopSize();
@@ -251,7 +251,7 @@ MUI.Dock = (MUI.Dock || new NamedClass('MUI.Dock',{})).implement({
 		if (this.options.useControls){
 			// Insert canvas
 			var canvas = new Element('canvas', {
-				'id':	 this.options.id+'Canvas',
+				'id':	 this.options.id + 'Canvas',
 				'width':  '15',
 				'height': '18'
 			}).inject(this.el.dock);
@@ -262,8 +262,8 @@ MUI.Dock = (MUI.Dock || new NamedClass('MUI.Dock',{})).implement({
 			}
 		}
 
-		var dockPlacement = $(this.options.id+'Placement');
-		var dockAutoHide = $(this.options.id+'AutoHide');
+		var dockPlacement = $(this.options.id + 'Placement');
+		var dockAutoHide = $(this.options.id + 'AutoHide');
 
 		// Position top or bottom selector
 		dockPlacement.setProperty('title', 'Position Dock Top');
@@ -287,8 +287,8 @@ MUI.Dock = (MUI.Dock || new NamedClass('MUI.Dock',{})).implement({
 
 		// Add check mark to menu if link exists in menu
 		if ($(this.options.menuCheck)) this.sidebarCheck = new Element('div', {
-				'class': 'check',
-				'id': this.options.id+'_check'
+			'class': 'check',
+			'id': this.options.id + '_check'
 		}).inject($(this.options.menuCheck));
 
 		this.dockSortables = new Sortables('#dockSort', {
@@ -302,15 +302,15 @@ MUI.Dock = (MUI.Dock || new NamedClass('MUI.Dock',{})).implement({
 		MUI.Desktop.setDesktopSize();
 	},
 
-	_doAutoHide: function(notoggle) {
+	_doAutoHide: function(notoggle){
 		if (this.el.wrapper.getProperty('position') == 'top')
 			return false;
 
-		var ctx = $(this.options.id+'Canvas').getContext('2d');
-		if(!notoggle) this.options.autoHide = !this.options.autoHide;	// Toggle
+		var ctx = $(this.options.id + 'Canvas').getContext('2d');
+		if (!notoggle) this.options.autoHide = !this.options.autoHide;	// Toggle
 
 		if (this.options.autoHide){
-			$(this.options.id+'AutoHide').setProperty('title', 'Turn Auto Hide Off');
+			$(this.options.id + 'AutoHide').setProperty('title', 'Turn Auto Hide Off');
 			//ctx.clearRect(0, 11, 100, 100);
 			MUI.Canvas.circle(ctx, 5, 14, 3, this.trueButtonColor, 1.0);
 			// Add event
@@ -346,7 +346,7 @@ MUI.Dock = (MUI.Dock || new NamedClass('MUI.Dock',{})).implement({
 
 	_renderDockControls: function(){
 		// Draw dock controls
-		var ctx = $(this.options.id+'Canvas').getContext('2d');
+		var ctx = $(this.options.id + 'Canvas').getContext('2d');
 		ctx.clearRect(0, 0, 100, 100);
 		MUI.Canvas.circle(ctx, 5, 4, 3, this.enabledButtonColor, 1.0);
 
@@ -373,7 +373,7 @@ MUI.Windows = (MUI.Windows || $H({})).extend({
 MUI.Window = (MUI.Window || new NamedClass('MUI.Window',{})).implement({
 
 	minimize: function(){
-		if(this.isMinimized) return this;
+		if (this.isMinimized) return this;
 		this.isMinimized = true;
 
 		// Hide iframe
@@ -396,7 +396,7 @@ MUI.Window = (MUI.Window || new NamedClass('MUI.Window',{})).implement({
 			}
 		}
 
-		if(MUI.Desktop) MUI.Desktop.setDesktopSize();
+		if (MUI.Desktop) MUI.Desktop.setDesktopSize();
 
 		// Have to use timeout because window gets focused when you click on the minimize button
 		setTimeout(function(){
@@ -425,7 +425,7 @@ MUI.Window = (MUI.Window || new NamedClass('MUI.Window',{})).implement({
 
 		this.isMinimized = false;
 		this.focus();
-		this.fireEvent('restore',[this]);
+		this.fireEvent('restore', [this]);
 	}
 
 });

--- a/Source/Core/Panel.js
+++ b/Source/Core/Panel.js
@@ -64,7 +64,7 @@ MUI.Panel = new NamedClass('MUI.Panel', {
 			isCollapsed: false, // This is probably redundant since we can check for the class
 			oldHeight: 0,
 			partner: null,
-			el:{}
+			el: {}
 		});
 
 		// If panel has no ID, give it one.
@@ -110,12 +110,12 @@ MUI.Panel = new NamedClass('MUI.Panel', {
 		// make sure we have a content sections
 		this.sections = [];
 
-		switch($type(options.content)) {
+		switch ($type(options.content)){
 			case 'string':
 				// was passed html, so make sure it is added
 				this.sections.push({
-					loadMethod:'html',
-					content:options.content
+					loadMethod: 'html',
+					content: options.content
 				});
 				break;
 			case 'array':
@@ -265,7 +265,7 @@ MUI.Panel = new NamedClass('MUI.Panel', {
 				'id': section.id,
 				'class': section.css
 			}).inject(intoEl);
-			if(section.height || $type(section.height)=='number') section.element.setStyle('height',section.height);
+			if (section.height || $type(section.height) == 'number') section.element.setStyle('height', section.height);
 
 			if (section.addClass) intoEl.addClass(section.addClass);
 

--- a/Source/Core/Persist.js
+++ b/Source/Core/Persist.js
@@ -66,7 +66,7 @@ MUI.Persist = (MUI.Persist || $H({})).extend({
 			divID:		'_persist_flash_wrap',	// ID of wrapper element
 			id:			'_persist_flash',				// id of flash object/embed
 			path:		'persist.swf',					// default path to flash object
-			height:	1,
+			height:		1,
 			width:		1,
 			params:	{									// arguments passed to flash object
 				autostart: true
@@ -456,14 +456,14 @@ MUI.Persist.Providers.IE = new Class({
 
 		// create element to store keys in
 		this.id = this.options.prefix + this._safeKey(this.options.name);
-		this.el = new Element('div', {'id':this.id,styles:{'display':'none'}}).inject(document.body);
+		this.el = new Element('div', {'id': this.id, styles: {'display': 'none'}}).inject(document.body);
 	},
 
 	get: function(key){
 		key = this._safeKey(key);
 
 		var val = this.el.retrieve(key); // get current value
-		this.fireEvent('get', [this,val,key]);
+		this.fireEvent('get', [this, val, key]);
 
 		return val;
 	},
@@ -473,7 +473,7 @@ MUI.Persist.Providers.IE = new Class({
 
 		var old_val = this.el.retrieve(key);  // get previous value
 		this.el.store(key, val);  // store new value
-		this.fireEvent('set', [this,val,key,old_val]);
+		this.fireEvent('set', [this, val, key, old_val]);
 
 		return old_val;
 	},
@@ -483,7 +483,7 @@ MUI.Persist.Providers.IE = new Class({
 
 		var old_val = this.el.retrieve(key);  // get previous value
 		this.el.eliminate(key);  // remove key
-		this.fireEvent('remove', [this,old_val,key]);
+		this.fireEvent('remove', [this, old_val, key]);
 
 		return old_val;
 	},
@@ -496,7 +496,7 @@ MUI.Persist.Providers.IE = new Class({
 
 MUI.Persist.Providers.Cookie = new Class({
 
-	Implements: [Events,Options],
+	Implements: [Events, Options],
 
 	options: {
 		size:	4000,			// 4k limit (low-ball this limit to handle browser weirdness, and so we don't hose session cookies)
@@ -523,7 +523,7 @@ MUI.Persist.Providers.Cookie = new Class({
 		key = this._safeKey(key);
 
 		var val = Cookie.read(key);  // get current value
-		this.fireEvent('get', [this,val,key]);
+		this.fireEvent('get', [this, val, key]);
 
 		return val;
 	},
@@ -533,7 +533,7 @@ MUI.Persist.Providers.Cookie = new Class({
 
 		var old_val = Cookie.read(key);  //get previous value
 		Cookie.write(key, val, this.options);  // store new value
-		this.fireEvent('set', [this,val,key,old_val]);
+		this.fireEvent('set', [this, val, key, old_val]);
 
 		return old_value;
 	},
@@ -543,7 +543,7 @@ MUI.Persist.Providers.Cookie = new Class({
 
 		var old_val = Cookie.read(key); // get old value
 		Cookie.dispose(key, this.options); // remove key
-		this.fireEvent('remove', [this,old_val,key]);
+		this.fireEvent('remove', [this, old_val, key]);
 
 		return old_val;
 	},
@@ -567,7 +567,7 @@ MUI.Persist.Providers.Flash = new Class({
 		this.setOptions(options);
 		if (!MUI.Persist.options.flash.el){
 			var cfg = this.options.flash;
-			cfg.container = new Element('div', {'id':this.options.flash.divID}).inject(document.body);
+			cfg.container = new Element('div', {'id': this.options.flash.divID}).inject(document.body);
 			MUI.Persist.options.flash.el = new Swiff(cfg.path, cfg);
 		}
 		this.el = MUI.Persist.options.flash.el;
@@ -577,7 +577,7 @@ MUI.Persist.Providers.Flash = new Class({
 		key = this._safeKey(key);
 
 		var val = this.el.get(this.options.name, key);  // get current value
-		this.fireEvent('get', [this,val,key]);
+		this.fireEvent('get', [this, val, key]);
 
 		return val;
 	},
@@ -586,7 +586,7 @@ MUI.Persist.Providers.Flash = new Class({
 		key = this._safeKey(key);
 
 		var old_val = this.el.set(this.options.name, key, val);  // get previous value, set new value
-		this.fireEvent('set', [this,val,key,old_val]);
+		this.fireEvent('set', [this, val, key, old_val]);
 
 		return old_val;
 	},
@@ -595,7 +595,7 @@ MUI.Persist.Providers.Flash = new Class({
 		key = this._safeKey(key);
 
 		var old_val = this.el.remove(this.options.name, key);  // remove key, and return previous value
-		this.fireEvent('remove', [this,val,key]);
+		this.fireEvent('remove', [this, val, key]);
 
 		return old_val;
 	},

--- a/Source/Core/Themes.js
+++ b/Source/Core/Themes.js
@@ -130,8 +130,7 @@ MUI.Themes = {
 		// Delay gives the stylesheets time to take effect. IE6 needs more delay.
 		if (Browser.Engine.trident){
 			this.redraw.delay(1250, this);
-		}
-		else {
+		} else {
 			this.redraw.delay(250, this);
 		}
 
@@ -150,7 +149,7 @@ MUI.Themes = {
 			instance.redraw();
 		});
 
-		if(MUI.dock) MUI.dock.setDockColors();
+		if (MUI.dock) MUI.dock.setDockColors();
 
 		// Reformat layout
 		if (MUI.Desktop && MUI.Desktop.desktop){
@@ -183,7 +182,7 @@ window.addEvent('load', function(){
 	 // Load theme the user was last using. This needs work.
 	 var cookie = new Hash.Cookie('mochaUIthemeCookie', {duration: 3600});
 	 var themeCookie = cookie.load();
-	 if(cookie.getKeys().length){
+	 if (cookie.getKeys().length){
 	 if (themeCookie.get('theme') != MUI.Themes.options.theme){
 	 MUI.Themes.init.delay(1000, MUI.Themes, themeCookie.get('theme'));
 	 }

--- a/Source/Core/Window.js
+++ b/Source/Core/Window.js
@@ -23,7 +23,7 @@ MUI.Windows = (MUI.Windows || $H({})).extend({
 	windowsVisible: true,		// Ctrl-Alt-Q to toggle window visibility
 	focusingWindow: false,
 
-	options:{
+	options: {
 		id:					null,
 		title:				'New Window',
 		icon:				false,
@@ -126,7 +126,7 @@ MUI.Windows = (MUI.Windows || $H({})).extend({
 				if (instance.sections){
 					instance.sections.each(function(section){
 						if (section.position == 'content') return;
-						var el=section.wrap ? section.wrapperEl : section.element;
+						var el = section.wrap ? section.wrapperEl : section.element;
 						if (el) el.setStyle('visibility', 'visible');
 					});
 				}
@@ -442,7 +442,7 @@ MUI.Window = (MUI.Window || new NamedClass('MUI.Window',{})).implement({
 			if (section.onLoaded) section.onLoaded = section.onLoaded.bind(this);
 			section.instance = this;
 			MUI.Content.update(section);
-		},this);
+		}, this);
 
 		this.redraw();
 
@@ -553,7 +553,7 @@ MUI.Window = (MUI.Window || new NamedClass('MUI.Window',{})).implement({
 		var width = this.el.contentWrapper.getStyle('width').toInt() + shadowBlur2x;
 		var height = this.el.contentWrapper.getStyle('height').toInt() + this.headerFooterShadow + borderHeight;
 		if (this.sections) this.sections.each(function(section){
-			if(section.position=='content') return;
+			if (section.position=='content') return;
 			var el = section.wrap ? section.wrapperEl : section.element;
 			height += el.getStyle('height').toInt() + el.getStyle('border-top').toInt();
 		} );
@@ -632,7 +632,7 @@ MUI.Window = (MUI.Window || new NamedClass('MUI.Window',{})).implement({
 	},
 
 	restore: function(){
-		if (this.isMinimized) { if(this._restoreMinimized) this._restoreMinimized(); }
+		if (this.isMinimized){ if (this._restoreMinimized) this._restoreMinimized(); }
 		else if (this.isMaximized && this._restoreMaximized) this._restoreMaximized();
 		return this;
 	},
@@ -664,7 +664,7 @@ MUI.Window = (MUI.Window || new NamedClass('MUI.Window',{})).implement({
 	resize: function(options){
 		var windowEl = this.el.windowEl;
 
-		options=$extend({
+		options = $extend({
 			width: null,
 			height: null,
 			top: null,
@@ -677,7 +677,7 @@ MUI.Window = (MUI.Window || new NamedClass('MUI.Window',{})).implement({
 		var oldTop = windowEl.getStyle('top').toInt();
 		var oldLeft = windowEl.getStyle('left').toInt();
 
-		var top,left;
+		var top, left;
 		if (options.centered){
 			top = typeof(options.top) != 'undefined' ? options.top : oldTop - ((options.height - oldHeight) * .5);
 			left = typeof(options.left) != 'undefined' ? options.left : oldLeft - ((options.width - oldWidth) * .5);
@@ -728,9 +728,9 @@ MUI.Window = (MUI.Window || new NamedClass('MUI.Window',{})).implement({
 	},
 
 	focus: function(fireEvent){
-		if(fireEvent==null) fireEvent=true;
+		if (fireEvent == null) fireEvent = true;
 		MUI.Windows.focusingWindow = true; // This is used with blurAll
-		(function() { MUI.Windows.focusingWindow = false; }).delay(170, this);
+		(function(){ MUI.Windows.focusingWindow = false; }).delay(170, this);
 
 		// Only focus when needed
 		var windowEl = this.el.windowEl;
@@ -765,7 +765,7 @@ MUI.Window = (MUI.Window || new NamedClass('MUI.Window',{})).implement({
 	},
 
 	hideSpinner: function(){
-		if (this.el.spinner)	this.el.spinner.hide();
+		if (this.el.spinner) this.el.spinner.hide();
 		return this;
 	},
 
@@ -816,7 +816,7 @@ MUI.Window = (MUI.Window || new NamedClass('MUI.Window',{})).implement({
 		return this;
 	},
 
-	collapseToggle: function() {
+	collapseToggle: function(){
 		var handles = this.el.windowEl.getElements('.handle');
 		if (this.isMaximized) return this;
 		if (this.isCollapsed){
@@ -830,7 +830,7 @@ MUI.Window = (MUI.Window || new NamedClass('MUI.Window',{})).implement({
 			});
 			if (this.sections){
 				this.sections.each(function(section){
-					if(section.position=='content') return;
+					if (section.position=='content') return;
 					var el = section.wrap ? section.wrapperEl : section.element;
 					if (el) el.setStyles({
 						visibility: 'visible',
@@ -854,7 +854,7 @@ MUI.Window = (MUI.Window || new NamedClass('MUI.Window',{})).implement({
 			});
 			if (this.sections){
 				this.sections.each(function(section){
-					if(section.position=='content') return;
+					if (section.position=='content') return;
 					var el = section.wrap ? section.wrapperEl : section.element;
 					if (el) el.setStyles({
 						visibility: 'hidden',
@@ -1183,13 +1183,13 @@ MUI.Window = (MUI.Window || new NamedClass('MUI.Window',{})).implement({
 		cache.footer = new Element('div', {
 			'id': id + '_footer',
 			'class': 'mochaWindowFooter',
-			'styles':{ 'width': width - 30 }
+			'styles': {'width': width - 30}
 		}).inject(cache.overlay, 'bottom');
 
 		// make sure we have a content sections
 		this.sections = [];
 
-		switch($type(options.content)) {
+		switch ($type(options.content)){
 			case 'string':
 				// was passed html, so make sure it is added
 				this.sections.push({
@@ -1234,7 +1234,7 @@ MUI.Window = (MUI.Window || new NamedClass('MUI.Window',{})).implement({
 			var where = section.position == 'bottom' ? 'after' : 'before';
 			var empty = section.empty;
 			if (section.position == 'header' || section.position == 'footer'){
-				if(!section.css) section.css='mochaToolbar';
+				if (!section.css) section.css='mochaToolbar';
 				intoEl = section.position == 'header' ? cache.titleBar : cache.footer;
 				where = 'bottom';
 				wrap = false;
@@ -1306,8 +1306,10 @@ MUI.Window = (MUI.Window || new NamedClass('MUI.Window',{})).implement({
 			cache.spinner = new Element('div', {
 				'id': id + '_spinner',
 				'class': 'mochaSpinner',
-				'styles':{	'width': 16,
-							'height': 16 }
+				'styles': {
+					'width': 16,
+					'height': 16
+				}
 			}).inject(cache.footer, 'bottom');
 		}
 
@@ -1465,7 +1467,7 @@ MUI.Window = (MUI.Window || new NamedClass('MUI.Window',{})).implement({
 		var height = 0;
 		if (this.sections){
 			this.sections.each(function(section){
-				if(section.position=='content') return;
+				if (section.position=='content') return;
 				height += section.wrapperEl.getStyle('height').toInt() + section.wrapperEl.getStyle('border-top').toInt();
 			});
 		}


### PR DESCRIPTION
Can call a Panel now, without having to specify a html resource (with url). This is useful if you want to load a Panel that just loads a js script that injects it's own interface into the panel.

Fixed some spaces 

Added better default value for options.requite.onload.
