### PR TITLE
MUI.Panel fix when header:false

### DIFF
--- a/Source/Controls/panel/Panel.js
+++ b/Source/Controls/panel/Panel.js
@@ -196,9 +196,9 @@ MUI.Panel = new NamedClass('MUI.Panel', {
 		}
 
 		if (columnInstance && columnInstance.options.sortable){
-			this.el.header.setStyle('cursor', 'move');
 			columnInstance.options.container.retrieve('sortables').addItems(this.el.element);
 			if (this.el.header){
+				this.el.header.setStyle('cursor', 'move');
 				this.el.header.addEvent('mousedown', function(e){
 					e = e.stop();
 					e.target.focus();


### PR DESCRIPTION
Move the cursor style setting for the header element into condition for header element so it is not called on non existent elements
